### PR TITLE
feat: change make file env GOBIN to GO

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Build
         env:
-          GOBIN: go
+          GO: go
         run: make build
 
       - name: Run unit tests
         env:
-          GOBIN: go
+          GO: go
           EDG_ORACLE_AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           EDG_ORACLE_AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta2/libwasmvm_
 RUN sha256sum /lib/libwasmvm_muslc.a | grep 3f5de8df9c6b606b4211f90edd681c84b0ecd870fdbf50678b6d9afd783a571c
 
 # Because we want to use 'libwasmvm_muslc.a', the 'muslc' build tag must be passed to build CosmWasm/wasmvm.
-RUN BUILD_TAGS=muslc GOBIN=go make build
+RUN BUILD_TAGS=muslc GO=go make build
 
 FROM alpine:edge
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export GO111MODULE = on
 
-GOBIN ?= ego-go
+GO ?= ego-go
 
 build_tags := $(strip $(BUILD_TAGS))
 BUILD_FLAGS := -tags "$(build_tags)"
@@ -12,10 +12,10 @@ OUT_DIR = ./build
 all: build test install
 
 build: go.sum
-	$(GOBIN) build -mod=readonly $(BUILD_FLAGS) -o $(OUT_DIR)/oracled ./cmd/oracled
+	$(GO) build -mod=readonly $(BUILD_FLAGS) -o $(OUT_DIR)/oracled ./cmd/oracled
 
 test:
-	GOBIN=$(GOBIN) ./run_gotest.sh
+	GO=$(GO) ./run_gotest.sh
 
 # Set env vars used by ./e2e/docker-compose.yml before running this target (recommended to use .env file).
 e2e-test:
@@ -23,12 +23,12 @@ e2e-test:
 	docker-compose -f ./e2e/docker-compose.yml up --build --force-recreate --abort-on-container-exit --exit-code-from e2e-test
 
 install: go.sum
-	$(GOBIN) install -mod=readonly $(BUILD_FLAGS) ./cmd/oracled
+	$(GO) install -mod=readonly $(BUILD_FLAGS) ./cmd/oracled
 
 # TODO: more args for private.pem
 ego-sign:
 	ego sign $(EXE)
 
 clean:
-	$(GOBIN) clean
+	$(GO) clean
 	rm -rf $(OUT_DIR)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ make test
 EXE="./build/oracled" make ego-sign
 ```
 
-If you build the `oracled` without using EGo, please run make commands with the explicit `GOBIN` environment variable.
+If you build the `oracled` without using EGo, please run make commands with the explicit `GO` environment variable.
 Then, enclave-related features will not work.
 
 ```bash
-GOBIN=go make build
-GOBIN=go make test
+GO=go make build
+GO=go make test
 ```
 
 ## Running

--- a/e2e/init_start_panacea.sh
+++ b/e2e/init_start_panacea.sh
@@ -39,14 +39,14 @@ ORACLE_ADDR=$(panacead keys show oracle -a)
 sed 's|"trusted_oracles": \[\]|"trusted_oracles": ["'"${ORACLE_ADDR}"'"]|g' ${SCRIPT_DIR}/create_deal.json >/tmp/create_deal.json
 sed 's|"trusted_oracles": \[\]|"trusted_oracles": ["'"${ORACLE_ADDR}"'"]|g' ${SCRIPT_DIR}/create_pool.json >/tmp/create_pool.json
 
-panacead tx datadeal create-deal /tmp/create_deal.json \
-  --from curator \
+panacead tx oracle register-node "https://my-endpoint.com" \
+  --from oracle \
   --chain-id ${CHAIN_ID} \
   -b block \
   --yes
 
-panacead tx datapool register-node "https://my-endpoint.com" \
-  --from oracle \
+panacead tx datadeal create-deal /tmp/create_deal.json \
+  --from curator \
   --chain-id ${CHAIN_ID} \
   -b block \
   --yes

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -26,7 +26,7 @@ ${GO} test -v ${NON_ENCLAVE_TEST_PKGS}
 #####################################################################
 echo "[Step 2] Running enclave tests..."
 
-if [ ${GO_BIN} != "ego-go" ]; then
+if [ ${GO} != "ego-go" ]; then
     echo "Skipping: EGo disabled"
     exit 0
 fi
@@ -40,7 +40,7 @@ for pkg in ${ENCLAVE_TEST_PKGS}; do
     ENCLAVE_JSON_PATH="${SCRIPT_DIR}/${PKG_DIR}/testdata/enclave.json"
     TEST_BIN_PATH="./$(jq -c '.exe' -r ${ENCLAVE_JSON_PATH})"
 
-    ${GO_BIN} test -c -o ${TEST_BIN_PATH} ${pkg}   # Compile the test binary but do not run it
+    ${GO} test -c -o ${TEST_BIN_PATH} ${pkg}   # Compile the test binary but do not run it
     ego sign ${ENCLAVE_JSON_PATH}                 # Sign the test binary for EGo
 
     # Run the test binary with env vars

--- a/run_gotest.sh
+++ b/run_gotest.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
-echo "GOBIN: ${GOBIN}"
+echo "GO: ${GO}"
 
 # NOTE: Please update this array if necessary
 PKG_PREFIX=$(grep '^module ' ./go.mod | awk "{print \$2}")
@@ -20,13 +20,13 @@ for pkg in ${ENCLAVE_TEST_PKGS[@]}; do
     NON_ENCLAVE_TEST_PKGS=$(echo "${NON_ENCLAVE_TEST_PKGS}" | grep -v ${pkg})
 done
 
-${GOBIN} test -v ${NON_ENCLAVE_TEST_PKGS}
+${GO} test -v ${NON_ENCLAVE_TEST_PKGS}
 
 
 #####################################################################
 echo "[Step 2] Running enclave tests..."
 
-if [ ${GOBIN} != "ego-go" ]; then
+if [ ${GO_BIN} != "ego-go" ]; then
     echo "Skipping: EGo disabled"
     exit 0
 fi
@@ -40,7 +40,7 @@ for pkg in ${ENCLAVE_TEST_PKGS}; do
     ENCLAVE_JSON_PATH="${SCRIPT_DIR}/${PKG_DIR}/testdata/enclave.json"
     TEST_BIN_PATH="./$(jq -c '.exe' -r ${ENCLAVE_JSON_PATH})"
 
-    ${GOBIN} test -c -o ${TEST_BIN_PATH} ${pkg}   # Compile the test binary but do not run it
+    ${GO_BIN} test -c -o ${TEST_BIN_PATH} ${pkg}   # Compile the test binary but do not run it
     ego sign ${ENCLAVE_JSON_PATH}                 # Sign the test binary for EGo
 
     # Run the test binary with env vars


### PR DESCRIPTION
When I run the `make install` command, the following error occurs.

```
> GOBIN=go make install
go install -mod=readonly -tags "" ./cmd/oracled
cannot install, GOBIN must be an absolute path
make: *** [install] Error 1
```

There is no problem with `GOBIN=go make build` or `GOBIN=go make test`.

It probably found the $GOBIN environment when running the `go install` command.

ref: https://pkg.go.dev/cmd/go
<img width="1230" alt="스크린샷 2022-06-07 오후 1 58 51" src="https://user-images.githubusercontent.com/10514738/172299655-252622e8-9c94-4990-8ef0-89ac7c5ba75f.png">

So, I changed environment `GOBIN` to `GO`