### PR TITLE
fix: query params big of get secret key handler and marshal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,7 @@ type Server struct {
 func New(svc *service.Service) *Server {
 	router := mux.NewRouter()
 	router.HandleFunc("/v0/data-deal/deals/{dealId}/data", svc.ValidateData).Methods("POST")
-	router.HandleFunc("/v0/data-deal/secret-key?deal-id={dealId}&data-hash={dataHash}}", svc.GetSecretKey).Methods("GET")
+	router.HandleFunc("/v0/data-deal/secret-key", svc.GetSecretKey).Methods("GET")
 
 	mw := middleware.NewJWTAuthMiddleware(svc.QueryClient())
 	router.Use(mw.Middleware)

--- a/service/handler_data_validation.go
+++ b/service/handler_data_validation.go
@@ -154,7 +154,7 @@ func (s *Service) ValidateData(w http.ResponseWriter, r *http.Request) {
 		Signature:           sig.Serialize(),
 	}
 
-	marshaledPayload, err := payload.Marshal()
+	marshaledPayload, err := json.Marshal(payload)
 	if err != nil {
 		log.Errorf("failed to marshal payload: %s", err.Error())
 		http.Error(w, "failed to marshal payload", http.StatusInternalServerError)

--- a/service/handler_secretkey.go
+++ b/service/handler_secretkey.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/gorilla/mux"
 	"github.com/medibloc/panacea-oracle/crypto"
 	"github.com/medibloc/panacea-oracle/server/middleware"
 	log "github.com/sirupsen/logrus"
@@ -17,7 +16,9 @@ func (svc *Service) GetSecretKey(w http.ResponseWriter, r *http.Request) {
 	queryClient := svc.QueryClient()
 	oraclePrivKey := svc.OraclePrivKey()
 
-	dealIDStr := mux.Vars(r)["dealId"]
+	queryParams := r.URL.Query()
+
+	dealIDStr := queryParams.Get("deal-id")
 	dealID, err := strconv.ParseUint(dealIDStr, 10, 64)
 	if err != nil {
 		log.Errorf("failed to parse deal ID: %s", err.Error())
@@ -25,7 +26,7 @@ func (svc *Service) GetSecretKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dataHashStr := mux.Vars(r)["dataHash"]
+	dataHashStr := queryParams.Get("data-hash")
 	dataHash, err := hex.DecodeString(dataHashStr)
 	if err != nil {
 		log.Errorf("failed to decode dataHash: %s", err.Error())


### PR DESCRIPTION
During test, I found 2 bugs and fixed.
- query params for `GetSecretKey` handler
- marshal differently compared with panacea-core in `ValidateData` handler