### PR TITLE
fix: check oracle_priv_key.sealed file when creating a new svc

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -59,15 +59,14 @@ func NewWithQueryClient(conf *config.Config, queryClient panacea.QueryClient) (S
 		return nil, err
 	}
 
-	if !os.FileExists(conf.AbsOraclePrivKeyPath()) {
-		return nil, fmt.Errorf("no sealed oracle private key file")
+	var oraclePrivKey *btcec.PrivateKey
+	if os.FileExists(conf.AbsOraclePrivKeyPath()) {
+		oraclePrivKeyBz, err := sgx.UnsealFromFile(conf.AbsOraclePrivKeyPath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to unseal oracle_priv_key.sealed file: %w", err)
+		}
+		oraclePrivKey, _ = crypto.PrivKeyFromBytes(oraclePrivKeyBz)
 	}
-
-	oraclePrivKeyBz, err := sgx.UnsealFromFile(conf.AbsOraclePrivKeyPath())
-	if err != nil {
-		return nil, fmt.Errorf("failed to unseal oracle_priv_key.sealed file: %w", err)
-	}
-	oraclePrivKey, _ := crypto.PrivKeyFromBytes(oraclePrivKeyBz)
 
 	selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -59,14 +59,15 @@ func NewWithQueryClient(conf *config.Config, queryClient panacea.QueryClient) (S
 		return nil, err
 	}
 
-	var oraclePrivKey *btcec.PrivateKey
-	if os.FileExists(conf.AbsOraclePubKeyPath()) {
-		oraclePrivKeyBz, err := sgx.UnsealFromFile(conf.AbsOraclePrivKeyPath())
-		if err != nil {
-			return nil, fmt.Errorf("failed to unseal oracle_priv_key.sealed file: %w", err)
-		}
-		oraclePrivKey, _ = crypto.PrivKeyFromBytes(oraclePrivKeyBz)
+	if !os.FileExists(conf.AbsOraclePrivKeyPath()) {
+		return nil, fmt.Errorf("no sealed oracle private key file")
 	}
+
+	oraclePrivKeyBz, err := sgx.UnsealFromFile(conf.AbsOraclePrivKeyPath())
+	if err != nil {
+		return nil, fmt.Errorf("failed to unseal oracle_priv_key.sealed file: %w", err)
+	}
+	oraclePrivKey, _ := crypto.PrivKeyFromBytes(oraclePrivKeyBz)
 
 	selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
 	if err != nil {


### PR DESCRIPTION
When creating a new service, wrong path check has been done, `conf.AbsOraclePubKeyPath`.
I changed to check `conf.AbsOraclePrivKeyPath`.
I also changed to return error if there is no `oracle_priv_key.sealed` file, because the oracle without oracle priv key can do nothing.