### PR TITLE
feat: add --from flag at get-oracle-key

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -10,4 +10,6 @@ const (
 	FlagOracleCommissionRate          = "oracle-commission-rate"
 	FlagOracleCommissionMaxRate       = "oracle-commission-max-rate"
 	FlagOracleCommissionMaxChangeRate = "oracle-commission-max-change-rate"
+
+	FlagFromOracleRegistrationOrUpgrade = "from"
 )

--- a/cmd/oracled/cmd/get_oracle_key.go
+++ b/cmd/oracled/cmd/get_oracle_key.go
@@ -10,6 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	fromRegistration = "registration"
+	fromUpgrade      = "upgrade"
+)
+
 func getOracleKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-oracle-key",
@@ -35,7 +40,8 @@ func getOracleKeyCmd() *cobra.Command {
 				return err
 			}
 
-			if from == "registration" {
+			switch from {
+			case fromRegistration:
 				oracleRegistration, err := svc.QueryClient().GetOracleRegistration(ctx, uniqueID, oracleAddress)
 				if err != nil {
 					return fmt.Errorf("failed to get oracle registration: %w", err)
@@ -46,7 +52,7 @@ func getOracleKeyCmd() *cobra.Command {
 				}
 				return key.RetrieveAndStoreOraclePrivKey(ctx, svc, oracleRegistration.EncryptedOraclePrivKey)
 
-			} else if from == "upgrade" {
+			case fromUpgrade:
 				oracleUpgrade, err := svc.QueryClient().GetOracleUpgrade(ctx, uniqueID, oracleAddress)
 				if err != nil {
 					return fmt.Errorf("failed to get oracle upgrade: %w", err)
@@ -55,10 +61,10 @@ func getOracleKeyCmd() *cobra.Command {
 					return fmt.Errorf("the encrypted oracle private key has not set yet. please try again later")
 				}
 				return key.RetrieveAndStoreOraclePrivKey(ctx, svc, oracleUpgrade.EncryptedOraclePrivKey)
-			} else {
+
+			default:
 				return fmt.Errorf("invalid --from flag input. please put \"registration\" or \"upgrade\"")
 			}
-
 		},
 	}
 

--- a/cmd/oracled/cmd/get_oracle_key.go
+++ b/cmd/oracled/cmd/get_oracle_key.go
@@ -62,7 +62,7 @@ func getOracleKeyCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(flags.FlagFromOracleRegistrationOrUpgrade, "upgrade", "where to get the key from (default \"upgrade\"")
+	cmd.Flags().String(flags.FlagFromOracleRegistrationOrUpgrade, "upgrade", "where to get the key from")
 
 	return cmd
 }

--- a/cmd/oracled/cmd/get_oracle_key.go
+++ b/cmd/oracled/cmd/get_oracle_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/medibloc/panacea-oracle/client/flags"
 	"github.com/medibloc/panacea-oracle/key"
 	"github.com/medibloc/panacea-oracle/service"
 	"github.com/spf13/cobra"
@@ -28,18 +29,40 @@ func getOracleKeyCmd() *cobra.Command {
 
 			uniqueID := svc.EnclaveInfo().UniqueIDHex()
 			oracleAddress := svc.OracleAcc().GetAddress()
-			oracleRegistration, err := svc.QueryClient().GetOracleRegistration(ctx, uniqueID, oracleAddress)
+
+			from, err := cmd.Flags().GetString(flags.FlagFromOracleRegistrationOrUpgrade)
 			if err != nil {
-				return fmt.Errorf("failed to get oracle registration: %w", err)
+				return err
 			}
 
-			if len(oracleRegistration.EncryptedOraclePrivKey) == 0 {
-				return fmt.Errorf("the encrypted oracle private key has not set yet. please try again later")
+			if from == "registration" {
+				oracleRegistration, err := svc.QueryClient().GetOracleRegistration(ctx, uniqueID, oracleAddress)
+				if err != nil {
+					return fmt.Errorf("failed to get oracle registration: %w", err)
+				}
+
+				if len(oracleRegistration.EncryptedOraclePrivKey) == 0 {
+					return fmt.Errorf("the encrypted oracle private key has not set yet. please try again later")
+				}
+				return key.RetrieveAndStoreOraclePrivKey(ctx, svc, oracleRegistration.EncryptedOraclePrivKey)
+
+			} else if from == "upgrade" {
+				oracleUpgrade, err := svc.QueryClient().GetOracleUpgrade(ctx, uniqueID, oracleAddress)
+				if err != nil {
+					return fmt.Errorf("failed to get oracle upgrade: %w", err)
+				}
+				if len(oracleUpgrade.EncryptedOraclePrivKey) == 0 {
+					return fmt.Errorf("the encrypted oracle private key has not set yet. please try again later")
+				}
+				return key.RetrieveAndStoreOraclePrivKey(ctx, svc, oracleUpgrade.EncryptedOraclePrivKey)
+			} else {
+				return fmt.Errorf("invalid --from flag input. please put \"registration\" or \"upgrade\"")
 			}
 
-			return key.RetrieveAndStoreOraclePrivKey(ctx, svc, oracleRegistration.EncryptedOraclePrivKey)
 		},
 	}
+
+	cmd.Flags().String(flags.FlagFromOracleRegistrationOrUpgrade, "upgrade", "where to get the key from (default \"upgrade\"")
 
 	return cmd
 }

--- a/cmd/oracled/cmd/get_oracle_key.go
+++ b/cmd/oracled/cmd/get_oracle_key.go
@@ -68,7 +68,7 @@ func getOracleKeyCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(flags.FlagFromOracleRegistrationOrUpgrade, "upgrade", "where to get the key from")
+	cmd.Flags().String(flags.FlagFromOracleRegistrationOrUpgrade, fromUpgrade, "where to get the key from")
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/ipfs/go-ipfs-api v0.3.0
 	github.com/lestrrat-go/jwx/v2 v2.0.8
-	github.com/medibloc/panacea-core/v2 v2.0.6-0.20230105013527-4f854a29b04d
+	github.com/medibloc/panacea-core/v2 v2.0.6-0.20230112003445-72ed7747a21b
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1382,8 +1382,6 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88J
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/medibloc/cosmos-sdk v0.45.9-panacea.1 h1:JTprXN6z/+6UjkjQU4OfDz7z+sUpzev1s9DywmWA2Sk=
 github.com/medibloc/cosmos-sdk v0.45.9-panacea.1/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
-github.com/medibloc/panacea-core/v2 v2.0.6-0.20230105013527-4f854a29b04d h1:s2+xmKkrJ7k9fKz5wJkpnbeCiuh7MVg5LFaFo4UoxE0=
-github.com/medibloc/panacea-core/v2 v2.0.6-0.20230105013527-4f854a29b04d/go.mod h1:YCYoLlbegqIP8fbrpvrvkK5LsQojDxukneKczbZ7hic=
 github.com/medibloc/panacea-core/v2 v2.0.6-0.20230112003445-72ed7747a21b h1:Xb4AM4Rs3tx1fUoMUNHqQ0xCbRZyo/eK0FwxzM+j4z4=
 github.com/medibloc/panacea-core/v2 v2.0.6-0.20230112003445-72ed7747a21b/go.mod h1:YCYoLlbegqIP8fbrpvrvkK5LsQojDxukneKczbZ7hic=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=

--- a/go.sum
+++ b/go.sum
@@ -1382,10 +1382,10 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88J
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/medibloc/cosmos-sdk v0.45.9-panacea.1 h1:JTprXN6z/+6UjkjQU4OfDz7z+sUpzev1s9DywmWA2Sk=
 github.com/medibloc/cosmos-sdk v0.45.9-panacea.1/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
-github.com/medibloc/panacea-core/v2 v2.0.6-0.20230104081432-e5cc1c5514cd h1:cljJCsJwn8rbk2NZW2klZ9rId5d3Bv/h6uEx0H/uhMI=
-github.com/medibloc/panacea-core/v2 v2.0.6-0.20230104081432-e5cc1c5514cd/go.mod h1:YCYoLlbegqIP8fbrpvrvkK5LsQojDxukneKczbZ7hic=
 github.com/medibloc/panacea-core/v2 v2.0.6-0.20230105013527-4f854a29b04d h1:s2+xmKkrJ7k9fKz5wJkpnbeCiuh7MVg5LFaFo4UoxE0=
 github.com/medibloc/panacea-core/v2 v2.0.6-0.20230105013527-4f854a29b04d/go.mod h1:YCYoLlbegqIP8fbrpvrvkK5LsQojDxukneKczbZ7hic=
+github.com/medibloc/panacea-core/v2 v2.0.6-0.20230112003445-72ed7747a21b h1:Xb4AM4Rs3tx1fUoMUNHqQ0xCbRZyo/eK0FwxzM+j4z4=
+github.com/medibloc/panacea-core/v2 v2.0.6-0.20230112003445-72ed7747a21b/go.mod h1:YCYoLlbegqIP8fbrpvrvkK5LsQojDxukneKczbZ7hic=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.2.1/go.mod h1:+Ro3wqY4vakcYNtkBWdZC7dBg1xSB6sp054wWwmeFm0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=


### PR DESCRIPTION
closes #70 .

To solve the issue, I added a flag `--from` to `get-oracle-key` CLI.
I also thought about how to automatically import the oracle key when upgraded, but adding a flag seemed the simplest to cover all cases of key loss. If there is a better way, please comment.

When I tested it in local environment, I confirmed that it works well.
