### PR TITLE
chore: reduce the trusted period

### DIFF
--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -56,7 +56,7 @@ type QueryClient interface {
 }
 
 const (
-	trustedPeriod = 2 * 365 * 24 * time.Hour
+	trustedPeriod = 2 * 7 * 24 * time.Hour
 )
 
 type TrustedBlockInfo struct {


### PR DESCRIPTION
The trusted period of 2 years was for testing purposes, change it to an appropriate value.

